### PR TITLE
chore: add app name mention in first channel selection view

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npx lerna run create-dynamodb-tables --scope=slack-app --stream
 
 **Run all packages**:
 ```
-$ npx lerna run dev --stream
+$ npx lerna run dev --stream --parallel
 ```
 
 [bolt-js]: https://slack.dev/bolt-js

--- a/packages/slack-app/nodemon-slack.json
+++ b/packages/slack-app/nodemon-slack.json
@@ -1,5 +1,6 @@
 {
   "exec": "ts-node src/handler-socket-mode.ts",
   "watch": ["./**/*.ts","../universal/dist/**/*"],
-  "ext": "ts"
+  "ext": "ts",
+  "delay": 300
 }

--- a/packages/universal/src/core/argument-config.ts
+++ b/packages/universal/src/core/argument-config.ts
@@ -1,5 +1,5 @@
-import { compact } from 'lodash'
-import { ChatPostMessageArguments, ChatPostEphemeralArguments, KnownBlock, ViewsOpenArguments } from '@slack/web-api'
+import { compact, omit } from 'lodash'
+import { ChatPostMessageArguments, ChatPostEphemeralArguments, KnownBlock, ViewsOpenArguments, ViewsUpdateArguments } from '@slack/web-api'
 import { ACTION_APP_USE_AGREEMENT, ACTIVATION_QUORUM, NOT_YET, ACTION_APP_FORCE_ACTIVATE, ACTION_OPEN_DIALOG_VOICE, CONST_SLASH_COMMAND, ACTION_SHOW_DEACTIVATE_WARNING, ACTION_SUBMISSION_INIT, CONST_APP_NAME } from '../models'
 import { STR_AGREEMENT_REQUIRED_DESC, STR_YOU_AREADY_AGREED, STR_AGREEMENT_ACCEPTED, STR_FORCE_ACTIVATE, STR_AGREE, STR_APP_ACTIVATED_BY_FORCE, STR_APP_DEACTIVATED_BY_FORCE, STR_FORCE_DEACTIVATE, STR_POST_VOICE, STR_YOU_HAVE_TO_AGREE_APP_USAGE, STR_HOW_TO_POST, STR_SLACK_APP_DOES_NOT_HAVE_PERMISSION1, STR_SLACK_APP_DOES_NOT_HAVE_PERMISSION2, STR_CONFIG_MSG, STR_QUESTION, STR_SERVER_VERSION } from '../models'
 import { IGroup } from '../types/type-group'
@@ -152,7 +152,7 @@ export const getErrorMsgChannelNotFound = () => {
   ].join('\n')
 }
 
-export const getSelectingChannelToInitialView = (trigger_id: string, pm: any): ViewsOpenArguments => {
+export const getSelectingChannelToInitialView = (trigger_id: string, pm: any, botUserId: string): ViewsOpenArguments => {
   return {
     trigger_id,
     view: {
@@ -186,7 +186,15 @@ export const getSelectingChannelToInitialView = (trigger_id: string, pm: any): V
               include: ['private'],
             },
           },
-        }
+        },
+        {
+          "block_id": "guide_message",
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": `<@${botUserId}>가 선택한 채널에 익명으로 메시지를 전달해줄꺼에요~`,
+          },
+        },
       ]
     }
   }


### PR DESCRIPTION
resolve #400 

- 채널에 앱을 초대 안하고 사용 시도 했을 때 DM을 통해 앱을 초대해달라는 안내 메시지를 보냈는데,
  이 부분이 불편함.
- 앱 이름을 멘션으로 View에 보여주고, 채널에 초대가 안되어 있을 때 DM 대신 에러 메시지로 이 멘션을 클릭하여 초대하라는 안내 메시지를
  View를 떠나지 않은 상태에서 제공하여 더 쉽게 앱 초대를 할 수 있도록 유도.

그 외:
- 개발 서버 실행이 잘 안되는 문제가 있어 가이드 문서를 수정 하였고, 
- 개발 서버 실행시 아래와 같이 처음 tsc로 인해 장황한 nodemon 로그가 찍히는 것을 delay 옵션을 주어 해결.

```
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] starting `ts-node src/handler-socket-mode.ts`
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/universal: 11:28:14 PM - Found 0 errors. Watching for file changes.
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] starting `ts-node src/handler-socket-mode.ts`
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] restarting due to changes...
@anonymouslack/slack-app: [nodemon] starting `ts-node src/handler-socket-mode.ts`
@anonymouslack/api: [tsoa:watch] [nodemon] clean exit - waiting for changes before restart
@anonymouslack/slack-app: ⚡️ Bolt app started
```